### PR TITLE
Update function names

### DIFF
--- a/jb-misc-functions.el
+++ b/jb-misc-functions.el
@@ -110,8 +110,8 @@ If there is no key-sequence for command then a string in the form \"M-x CMD\" wi
 		       (if (listp keymaps)
 			   ;; Note: don't bother trying to put this function in
 			   ;; a cl-flet form, or you won't be able to do the mapcar
-			   (mapcar 'eval-keymap keymaps)
-			 (eval-keymap keymaps))))
+			   (mapcar 'jb-eval-keymap keymaps)
+			 (jb-eval-keymap keymaps))))
 	 (key (where-is-internal cmd (or keymaps2 overriding-local-map) (unless sep t))))
     (if key
         (if sep


### PR DESCRIPTION
`eval-keymap` was renamed to `jb-eval-keymap` at 81f42b9e65690b6bf4cc5eafc47b7f9cbeca2e.
